### PR TITLE
refactor: use official commitizen-action for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,34 +4,32 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch:
-    inputs:
-      bump_type:
-        description: Version bump type
-        required: true
-        type: choice
-        options:
-        - patch
-        - minor
-        - major
 
 permissions:
   contents: write
-  pull-requests: write
 
 jobs:
   release:
-    name: Create Release
+    name: Bump version and create release
+    if: "!startsWith(github.event.head_commit.message, 'bump:')"
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout code
+    - name: Check out
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         fetch-depth: 0
-        fetch-tags: true
-        token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
-        persist-credentials: true
+        token: ${{ secrets.RELEASE_TOKEN }}
+
+    - name: Create bump and changelog
+      id: cz
+      uses: commitizen-tools/commitizen-action@master
+      with:
+        github_token: ${{ secrets.RELEASE_TOKEN }}
+        changelog_increment_filename: body.md
+
+    - name: Print Version
+      run: echo "Bumped to version ${{ steps.cz.outputs.version }}"
 
     - name: Install uv
       uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4.2.0
@@ -39,52 +37,14 @@ jobs:
     - name: Set up Python
       run: uv python install 3.12
 
-    - name: Install dependencies
-      run: uv sync --all-extras
-
-    - name: Fetch all tags
-      run: git fetch --tags --force
-
-    - name: Configure Git
-      run: |
-        git config --global user.name "github-actions[bot]"
-        git config --global user.email "github-actions[bot]@users.noreply.github.com"
-
-    - name: Determine version bump type
-      id: bump_type
-      run: |
-        if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-          echo "type=${{ github.event.inputs.bump_type }}" >> $GITHUB_OUTPUT
-        else
-          # Auto-detect from commit messages (feat: = minor, fix: = patch, breaking: = major)
-          echo "type=auto" >> $GITHUB_OUTPUT
-        fi
-
-    - name: Bump version and update changelog
-      run: |
-        BUMP_TYPE="${{ steps.bump_type.outputs.type }}"
-        if [ "$BUMP_TYPE" = "auto" ]; then
-          uv run cz bump --yes
-        else
-          uv run cz bump --increment $BUMP_TYPE --yes
-        fi
-        echo "NEW_VERSION=$(uv run cz version --project)" >> $GITHUB_ENV
-
-    - name: Push changes
-      run: |
-        git push
-        git push --tags
-
     - name: Build package
       run: uv build
 
     - name: Create GitHub Release
       uses: softprops/action-gh-release@6da8fa9354ddfdc4aeace5fc48d7f679b5214090 # v2.4.1
       with:
-        tag_name: v${{ env.NEW_VERSION }}
-        name: Release v${{ env.NEW_VERSION }}
-        body_path: CHANGELOG.md
-        files: |
-          dist/*
-        draft: false
-        prerelease: false
+        body_path: body.md
+        tag_name: ${{ steps.cz.outputs.version }}
+        files: dist/*
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Replace custom `cz bump` implementation with the official `commitizen-action` to fix release automation issues and follow best practices.

## Changes

- ✅ Use `commitizen-tools/commitizen-action@master` for automated version bumping
- ✅ Add skip condition `if: "!startsWith(github.event.head_commit.message, 'bump:')"` to prevent infinite loops
- ✅ Simplify workflow - action handles bump, changelog, commit, tag, and push automatically
- ✅ Use `fetch-depth: 0` for full git history (required by commitizen)
- ✅ Generate `body.md` for release notes
- ✅ Remove manual `workflow_dispatch` - now automatic on push to main only
- ✅ Use `RELEASE_TOKEN` for bypassing branch protection

## Why This Change?

Our previous custom implementation had issues:
- Incremental changelog generation failing ("No tag found")
- Complex manual tag and commit management
- Error-prone bash scripts

The official action:
- ✅ Maintained by commitizen team
- ✅ Handles all edge cases automatically
- ✅ Proven in production by many projects
- ✅ Follows official best practices

## Testing

After merging, the workflow will automatically:
1. Detect version bump from commit messages (feat: = minor, fix: = patch, BREAKING CHANGE = major)
2. Update version in pyproject.toml and CHANGELOG.md
3. Create and push version bump commit
4. Create and push git tag (e.g., v1.0.0)
5. Build wheel and source distribution
6. Create GitHub Release with artifacts

## References

- [Commitizen GitHub Actions Tutorial](https://commitizen-tools.github.io/commitizen/tutorials/github_actions/)
- [commitizen-action Repository](https://github.com/commitizen-tools/commitizen-action)