### PR TITLE
fix: pin commitizen-action to full commit SHA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
 
     - name: Create bump and changelog
       id: cz
-      uses: commitizen-tools/commitizen-action@master
+      uses: commitizen-tools/commitizen-action@5b0848cd060263e24602d1eba03710e056ef7711 # master
       with:
         github_token: ${{ secrets.RELEASE_TOKEN }}
         changelog_increment_filename: body.md


### PR DESCRIPTION
## Summary
Pin commitizen-action to full commit SHA to comply with repository security requirements.

## Changes
- Pin `commitizen-tools/commitizen-action@master` to commit SHA `5b0848cd060263e24602d1eba03710e056ef7711`

## Context
After merging PR #4, the release workflow failed with:
```
The action commitizen-tools/commitizen-action@master is not allowed in champi-ai/champi-gen-ui 
because all actions must be pinned to a full-length commit SHA
```

This PR fixes the security compliance issue by pinning the action to the full commit SHA of the master branch.

## Testing
Once merged, the release workflow should run successfully and create a new release.