### PR TITLE
fix: add Docker Hub logout workaround for auth issues

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,9 @@ jobs:
         fetch-depth: 0
         token: ${{ secrets.RELEASE_TOKEN }}
 
+    - name: Workaround for Docker Hub auth issues
+      run: docker logout docker.io
+
     - name: Create bump and changelog
       id: cz
       uses: commitizen-tools/commitizen-action@5b0848cd060263e24602d1eba03710e056ef7711 # master


### PR DESCRIPTION
## Summary
Add `docker logout docker.io` step to prevent Docker Hub authentication failures.

## Problem
The release workflow was failing with Docker Hub 503 errors:
```
ERROR: failed to authorize: failed to fetch oauth token: unexpected status from POST request 
to https://auth.docker.io/token: 503 Service Unavailable
```

## Solution
Added a `docker logout docker.io` step before the commitizen-action to clear any stale or corrupted authentication tokens. This is a known workaround for transient Docker Hub auth issues.

## Reference
- https://github.com/docker/buildx/issues/1102#issuecomment-2231549818

## Testing
Once merged, the release workflow should successfully build the Docker image for commitizen-action and create a new release.