### PR TITLE
fix: handle incremental changelog extraction properly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,16 +43,40 @@ jobs:
         echo "Previous version: $PREV_REV"
 
         # Run commitizen bump with changelog
-        cz bump --yes --changelog --changelog-to-stdout > body.md
+        # --no-raise 21: Don't fail on "No commits to bump" (exit code 21)
+        cz --no-raise 21 bump --yes --changelog
 
         # Get new version
         REV=$(cz version --project)
         echo "New version: $REV"
-        echo "version=${REV}" >> $GITHUB_OUTPUT
+        echo "version=v${REV}" >> $GITHUB_OUTPUT
 
-        # Push changes if version changed
+        # Extract incremental changelog for this version
+        # Get content between the new version header and the previous version header
         if [[ "$REV" != "$PREV_REV" ]]; then
+          # Try to extract just the new version's changelog
+          sed -n "/## v${REV}/,/## v${PREV_REV}/p" CHANGELOG.md | sed '$d' > body.md
+
+          # If body.md is empty, fall back to using the entire new version section
+          if [[ ! -s body.md ]]; then
+            sed -n "/## v${REV}/,/## /p" CHANGELOG.md | sed '$d' > body.md
+          fi
+
+          # If still empty, use a default message
+          if [[ ! -s body.md ]]; then
+            echo "Release v${REV}" > body.md
+            echo "" >> body.md
+            echo "See [CHANGELOG.md](CHANGELOG.md) for details." >> body.md
+          fi
+
+          echo "Incremental changelog:"
+          cat body.md
+
+          # Push changes and tags
           git push origin main --follow-tags
+        else
+          echo "No version change, skipping release"
+          echo "No changes" > body.md
         fi
 
     - name: Print Version


### PR DESCRIPTION
## Summary
Fix changelog extraction to avoid `--changelog-to-stdout` errors when no previous tags are found.

## Problem
The workflow was failing with exit code 16:
```
No tag found to do an incremental changelog
```

The `--changelog-to-stdout` flag tries to generate an incremental changelog but fails when it can't find a previous tag to compare against.

## Solution
- Remove `--changelog-to-stdout` which requires previous tags
- Generate full changelog with `--changelog` instead
- Extract incremental changes using `sed` from the updated CHANGELOG.md
- Add fallback logic if extraction fails
- Add `v` prefix to version output for consistency with git tags

## Changes
1. Use `cz bump --yes --changelog` without stdout redirect
2. Parse CHANGELOG.md to extract just the new version's content
3. Handle edge cases with fallback messages
4. Fix version output to include `v` prefix (v2.0.0 not 2.0.0)

## Testing
Once merged, the workflow should successfully:
- Bump version from 1.0.0 to 2.0.0 (MAJOR bump)
- Generate changelog entry
- Extract incremental changelog for GitHub Release
- Create release with proper tag